### PR TITLE
CommonJS default export convenience hack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+/*
+ * This file is just a small hack to allow CommonJS require()-ing
+ * the default export as:
+ *
+ * const createSubscriber = require("pg-listen")
+ */
+
+const moduleExports = require("./dist/index")
+const createPosgresSubscriber = moduleExports.default
+
+module.exports = Object.assign(createPosgresSubscriber, moduleExports)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "PostgreSQL LISTEN &  NOTIFY that finally works.",
   "author": "Andy Wermke (https://github.com/andywer)",
   "repository": "github:andywer/pg-listen",
-  "main": "./dist/index.js",
+  "main": "./index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "typescript": "^3.0.3"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "index.js"
   ],
   "ava": {
     "serial": true


### PR DESCRIPTION
Allows importing from the library like this:

```js
const createSubscriber = require("pg-listen")
```

Closes #6.