### PR TITLE
Check debug is enabled (perfomance bug)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,10 @@ function createPostgresSubscriber<Events extends Record<string, any> = { [channe
       dbClient = await reconnect(attempt => emitter.emit("reconnect", attempt))
       initialize(dbClient)
 
-      subscriptionLogger(`Re-subscribing to channels: ${subscribedChannels.join(", ")}`)
+      if (subscriptionLogger.enabled) {
+        subscriptionLogger(`Re-subscribing to channels: ${subscribedChannels.join(", ")}`)
+      }
+
       await Promise.all(subscribedChannels.map(
         channelName => dbClient.query(`LISTEN ${format.ident(channelName)}`)
       ))


### PR DESCRIPTION
We are going to use your package in our backend with 20000-30000 active listeners per each node.js instance (during peak hours we have ~10000 active websocket connections and 20-30 active graphql subscriptions per each connection, they are not reusable, because each user listens for his own data), so joining that amount of channels to one string will be very slow for our use case.